### PR TITLE
Eliminated a bunch of warnings with Ruby 1.9.2p136 (and Rails 3.0.6)

### DIFF
--- a/lib/nickel/query.rb
+++ b/lib/nickel/query.rb
@@ -1,4 +1,4 @@
-# Ruby Nickel Library 
+# Ruby Nickel Library
 # Copyright (c) 2008-2011 Lou Zell, lzell11@gmail.com, http://hazelmade.com
 # MIT License [http://www.opensource.org/licenses/mit-license.php]
 
@@ -6,10 +6,10 @@ module Nickel
 
   class NLPQuery < String
     include NLPQueryConstants
-    
+
     # Note there is no initialize here, it is inherited from string class.
     attr_reader :after_formatting, :changed_in, :message
-    
+
     def standardize
       @query = self.dup # needed for case correcting after extract_message has been called
       query_formatting  # easy text manipulation, no regex involved here
@@ -33,12 +33,12 @@ module Nickel
       insert_space_at_end_of_string_lame
       @after_formatting = self.dup    # save current state
     end
-  
-    # Usage: 
+
+    # Usage:
     #   self.nsub!(/foo/, 'bar')
     #
     # nsub! is like gsub! except it logs the calling method in @changed_in.
-    # There is another difference: When using blocks, matched strings are 
+    # There is another difference: When using blocks, matched strings are
     # available as block params, e.g.: # nsub!(/(match1)(match2)/) {|m1,m2|}
     #
     # I wrote this because I was having problems overriding gsub and passing
@@ -49,7 +49,7 @@ module Nickel
         @changed_in ||= []
         @changed_in << calling_method
         if block_given?
-          # gsub!(args[0]) {yield(*m.to_a[1..-1])}    # There is a bug here: If gsub matches more than once, 
+          # gsub!(args[0]) {yield(*m.to_a[1..-1])}    # There is a bug here: If gsub matches more than once,
                                                       # then the first set of referenced matches will be passed to the block
           ret_str = m.pre_match + m[0].sub(args[0]) {yield(*m.to_a[1..-1])}   # this will take care of the first set of matches
           while (m_old = m.dup) && (m = m.post_match.match(args[0]))
@@ -112,7 +112,7 @@ module Nickel
       nsub!(/\s*at\s+night/,'pm')
       nsub!(/(after\s*)?noon(ish)?/,'12:00pm')
       nsub!(/\bmi(dn|nd)ight\b/,'12:00am')
-      nsub!(/final/,'last') 
+      nsub!(/final/,'last')
       nsub!(/recur(s|r?ing)?/,'repeats')
       nsub!(/\beach\b/,'every')
       nsub!(/running\s+(until|through)/,'through')
@@ -120,7 +120,7 @@ module Nickel
       nsub!(/next\s+occ?urr?[ae]nce(\s+is)?/,'start')
       nsub!(/next\s+date(\s+it)?(\s+occ?urr?s)?(\s+is)?/,'start')
       nsub!(/forever/,'repeats daily')
-      nsub!(/\bany(?:\s+)?day\b/,'every day')
+      nsub!(/\bany(?:\s)*day\b/,'every day')
       nsub!(/^anytime$/,'every day')  # user entered anytime by itself, not 'dayname anytime', caught next
       nsub!(/any(\s)?time|whenever/,'all day')
     end
@@ -186,7 +186,7 @@ module Nickel
       nsub!(/\bninety\s*-?\s*fifth\b/,'95th')
       nsub!(/\bninety\s*-?\s*four\b/,'94')
       nsub!(/\bninety\s*-?\s*fourth\b/,'94th')
-      nsub!(/\bninety\s*-?\s*three\b/,'93')                   
+      nsub!(/\bninety\s*-?\s*three\b/,'93')
       nsub!(/\bninety\s*-?\s*third\b/,'93rd')
       nsub!(/\bninety\s*-?\s*two\b/,'92')
       nsub!(/\bninety\s*-?\s*second\b/,'92nd')
@@ -198,7 +198,7 @@ module Nickel
       nsub!(/\beighty\s*-?\s*ninth\b/,'89th')
       nsub!(/\beighty\s*-?\s*eight\b/,'88')
       nsub!(/\beighty\s*-?\s*eighth\b/,'88th')
-      nsub!(/\beighty\s*-?\s*seven\b/,'87')                  
+      nsub!(/\beighty\s*-?\s*seven\b/,'87')
       nsub!(/\beighty\s*-?\s*seventh\b/,'87th')
       nsub!(/\beighty\s*-?\s*six\b/,'86')
       nsub!(/\beighty\s*-?\s*sixth\b/,'86th')
@@ -373,12 +373,12 @@ module Nickel
       nsub!(/\bone\b/,'1')
       nsub!(/\bfirst\b/,'1st')
       nsub!(/\bzero\b/,'0')
-      nsub!(/\bzeroth\b/,'0th')  
+      nsub!(/\bzeroth\b/,'0th')
     end
 
     def standardize_am_pm
-      nsub!(/([0-9])(?:\s+)?a\b/,'\1am')  # allows 5a as 5am
-      nsub!(/([0-9])(?:\s+)?p\b/,'\1pm')  # allows 5p as 5pm
+      nsub!(/([0-9])(?:\s)*a\b/,'\1am')  # allows 5a as 5am
+      nsub!(/([0-9])(?:\s)*p\b/,'\1pm')  # allows 5p as 5pm
       nsub!(/\s+am\b/,'am')  # removes any spaces before am, shouldn't I check for preceeding digits?
       nsub!(/\s+pm\b/,'pm')  # removes any spaces before pm, shouldn't I check for preceeding digits?
     end
@@ -473,7 +473,7 @@ module Nickel
       c_d_e = /^(\d{1,2}):(\d{1,2})(am|pm)?$/           # handles cases (c), (d), and (e)
       if mdata = match(a_b)
         am_pm = mdata[2]
-        case mdata[1].length                            # this may look a bit confusing, but all we are doing is interpreting    
+        case mdata[1].length                            # this may look a bit confusing, but all we are doing is interpreting
           when 1 then hstr = "0" + mdata[1]                 # what the user meant based on the number of digits they provided
           when 2 then hstr = mdata[1]                                       # e.g. "11" means 11:00
           when 3 then hstr = "0" + mdata[1][0..0]; mstr = mdata[1][1..2]    # e.g. "530" means 5:30
@@ -489,20 +489,20 @@ module Nickel
         return nil
       end
       # in this case we do not care if time fails validation, if it does, it just means we haven't found a valid time, return nil
-      begin ZTime.new("#{hstr}#{mstr}", am_pm) rescue return nil end 
+      begin ZTime.new("#{hstr}#{mstr}", am_pm) rescue return nil end
     end
 
     # Interpret Date is equally as important, our goals:
     # First off, convention of the NLP is to not allow month names to the construct finder (unless it is implying date span), so we will not be interpreting
     # anything such as january 2nd, 2008.  Instead all dates will be represented in this form month/day/year.  However it may not
-    # be as nice as that.  We need to match things like '5', if someone just typed in "the 5th."  Because of this, there will be 
-    # overlap between interpret_date and interpret_time in matching; interpret_date should ALWAYS be found after interpret_time in 
+    # be as nice as that.  We need to match things like '5', if someone just typed in "the 5th."  Because of this, there will be
+    # overlap between interpret_date and interpret_time in matching; interpret_date should ALWAYS be found after interpret_time in
     # the construct finder.  If the construct finder happens upon a digit on it's own, e.g. "5", it will not run interpret_time
     # because there is no "at" preceeding it.  Therefore it will fall through to the finder with interpret_date and we will assume
     # the user meant the 5th.  If interpret_date is before interpret_time, then .... wait... does the order actually matter?  Even if
     # this is before interpret_time, it shouldn't get hit because the time should be picked up at the "at" construct.  This may be a bunch
     # of useless rambling.
-    # 
+    #
     # 2/08      <------ This is not A date
     # 2/2008    <------ Neither is this, but I can see people using these as wrappers, must support this in next version
     # 11/08     <------ same
@@ -530,7 +530,7 @@ module Nickel
       a_d = /^(\d{1,2})(rd|st|nd|th)?$/     # handles cases a and d
       b = /^(\d{1,2})\/(\d{1,2})$/          # handles case b
       c = /^(\d{1,2})\/(\d{1,2})\/(\d{2}|\d{4})$/   # handles case c
-      
+
       if mdata = match(a_d)
         ambiguous[:month] = true
         day_str = mdata[1].to_s2
@@ -545,7 +545,7 @@ module Nickel
       else
         return nil
       end
-      
+
       inst_str = (year_str || current_date.year_str) + (month_str || current_date.month_str) + (day_str || current_date.day_str)
       # in this case we do not care if date fails validation, if it does, it just means we haven't found a valid date, return nil
       date = ZDate.new(inst_str) rescue nil
@@ -566,11 +566,11 @@ module Nickel
       def @logger.blue(a)
         #self.warn "\e[44m #{a.inspect} \e[0m"
       end
-      
+
       @logger.blue self
       # message could be all components put back together (which would be @nlp_query), so start with that
       message_array = self.split
-      
+
       # now iterate through constructs, blow away any words between positions comp_start and comp_end
       constructs.each do |c|
         # create a range between comp_start and comp_end, iterate through it and wipe out words between them
@@ -583,7 +583,7 @@ module Nickel
             if $1 == "on" && c.comp_start - 3 >= 0 && message_array[c.comp_start - 3] =~ /\b(is|are)\b/         # is on the 28th;  are on the 21st and 22nd;
               message_array[c.comp_start - 3] = nil
             end
-          elsif $1 == "on" && c.comp_start - 2 >= 0 && message_array[c.comp_start - 2] =~ /\b(is|are)\b/      # is on tuesday; are on tuesday and wed; 
+          elsif $1 == "on" && c.comp_start - 2 >= 0 && message_array[c.comp_start - 2] =~ /\b(is|are)\b/      # is on tuesday; are on tuesday and wed;
             message_array[c.comp_start - 2] = nil
           end
         end
@@ -591,7 +591,7 @@ module Nickel
         @logger.blue(c.comp_start)
         @logger.blue(c.comp_end)
       end
-      
+
       # reloop and wipe out words after end of constructs, if they are followed by another construct
       # note we already wiped out terms ahead of the constructs, so be sure to check for nil values, these indicate that a construct is followed by the nil
       constructs.each_with_index do |c, i|
@@ -610,7 +610,7 @@ module Nickel
       # we have the message, now run the case corrector to return cases to the users original input
       case_corrector
     end
-    
+
     # returns any words in the query that appeared as input to their original case
     def case_corrector
       orig = @query.split
@@ -622,7 +622,7 @@ module Nickel
       end
       @message = latest.join(" ")
     end
-    
+
 
     private
     def standardize_input
@@ -631,29 +631,29 @@ module Nickel
       nsub!(/^(through|until)/,'today through')   # ^through  =>  today through
       nsub!(/every\s*(night|morning)/,'every day')
       nsub!(/tonight/,'today')
-      nsub!(/this(?:\s+)?morning/,'today')
+      nsub!(/this(?:\s)*morning/,'today')
       nsub!(/before\s+12pm/,'6am to 12pm')        # arbitrary
 
       # Handle 'THE' Cases
-      # Attempt to pick out where a user entered 'the' when they really mean 'every'. 
-      # For example, 
+      # Attempt to pick out where a user entered 'the' when they really mean 'every'.
+      # For example,
       # The first of every month and the 22nd of THE month  =>  repeats monthly first xxxxxx repeats monthly 22nd xxxxxxx
       nsub!(/(?:the\s+)?#{DATE_DD_WITH_SUFFIX}\s+(?:of\s+)?(?:every|each)\s+month((?:.*)of\s+the\s+month(?:.*))/) do |m1,m2|
         ret_str = " repeats monthly " + m1
         ret_str << m2.gsub(/(?:and\s+)?(?:the\s+)?#{DATE_DD_WITH_SUFFIX}\s+of\s+the\s+month/, ' repeats monthly \1 ')
       end
-      
+
       # Every first sunday of the month and the last tuesday  =>  repeats monthly first sunday xxxxxxxxx repeats monthly last tuesday xxxxxxx
       nsub!(/every\s+#{WEEK_OF_MONTH}\s+#{DAY_OF_WEEK}\s+of\s+(?:the\s+)?month((?:.*)and\s+(?:the\s+)?#{WEEK_OF_MONTH}\s+#{DAY_OF_WEEK}(?:.*))/) do |m1,m2,m3|
         ret_str = " repeats monthly " + m1 + " " + m2 + " "
-        ret_str << m3.gsub(/and\s+(?:the\s+)?#{WEEK_OF_MONTH}\s+#{DAY_OF_WEEK}(?:\s+)?(?:of\s+)?(?:the\s+)?(?:month\s+)?/, ' repeats monthly \1 \2 ')
+        ret_str << m3.gsub(/and\s+(?:the\s+)?#{WEEK_OF_MONTH}\s+#{DAY_OF_WEEK}(?:\s)*(?:of\s+)?(?:the\s+)?(?:month\s+)?/, ' repeats monthly \1 \2 ')
       end
 
       # The x through the y of oct z  =>  10/x/z through 10/y/z
       nsub!(/(?:the\s+)?#{DATE_DD}\s+(?:through|to|until)\s+(?:the\s+)?#{DATE_DD}\s(?:of\s+)#{MONTH_OF_YEAR}\s+(?:of\s+)?#{YEAR}/) do |m1,m2,m3,m4|
         (ZDate.months_of_year.index(m3) + 1).to_s + '/' + m1 + '/' + m4 + ' through ' +  (ZDate.months_of_year.index(m3) + 1).to_s + '/' + m2 + '/' + m4
       end
-      
+
       # The x through the y of oct  =>  10/x through 10/y
       nsub!(/(?:the\s+)?#{DATE_DD}\s+(?:through|to|until)\s+(?:the\s+)#{DATE_DD}\s(?:of\s+)?#{MONTH_OF_YEAR}/) do |m1,m2,m3|
         (ZDate.months_of_year.index(m3) + 1).to_s + '/' + m1 + ' through ' + (ZDate.months_of_year.index(m3) + 1).to_s + '/' + m2
@@ -669,7 +669,7 @@ module Nickel
           (ZDate.months_of_year.index(m1) + 1).to_s + '/' + m2 + ' through ' + (ZDate.months_of_year.index(m1) + 1).to_s + '/' + m4
         end
       end
-      
+
       # Monthname x through monthname y
       # Jan 14 through jan 18  =>  1/14 through 1/18
       # Oct 2 until oct 5
@@ -678,28 +678,28 @@ module Nickel
           (ZDate.months_of_year.index(m1) + 1).to_s + '/' + m2 + '/' + m5 + ' through ' + (ZDate.months_of_year.index(m3) + 1).to_s + '/' + m4 + '/' + m5 + ' '
         else
           (ZDate.months_of_year.index(m1) + 1).to_s + '/' + m2 + ' through ' + (ZDate.months_of_year.index(m3) + 1).to_s + '/' + m4 + ' '
-        end       
+        end
       end
-    
+
       # Mnday the 23rd, tuesday the 24th and wed the 25th of oct  =>  11/23 11/24 11/25
       nsub!(/((?:#{DAY_OF_WEEK_NB}\s+the\s+#{DATE_DD_WITH_SUFFIX_NB}\s+(?:and\s+)?){1,31})of\s+#{MONTH_OF_YEAR}\s*(#{YEAR})?/) do |m1,m2,m3|
         month_str = (ZDate.months_of_year.index(m2) + 1).to_s
         if m3
           m1.gsub(/\b(and|the)\b|#{DAY_OF_WEEK}/,'').gsub(/#{DATE_DD_NB_ON_SUFFIX}/, month_str + '/\1/' + m3)
-        else                                                 
+        else
           m1.gsub(/\b(and|the)\b|#{DAY_OF_WEEK}/,'').gsub(/#{DATE_DD_NB_ON_SUFFIX}/, month_str + '/\1')
         end
       end
-      
+
       # the 23rd and 24th of october                    =>  11/23 11/24
-      # the 23rd, 24th, and 25th of october             =>  11/23 11/24 11/25                                                                                                                                              
+      # the 23rd, 24th, and 25th of october             =>  11/23 11/24 11/25
       # the 23rd, 24th, and 25th of october 2010        =>  11/23/2010 11/24/2010 11/25/2010
       # monday and tuesday, the 23rd and 24th of july   =>  7/23 7/24
       nsub!(/(?:(?:#{DAY_OF_WEEK_NB}\s+(?:and\s+)?){1,7})?(?:the\s+)?((?:#{DATE_DD_WITH_SUFFIX_NB}\s+(?:and\s+)?(?:the\s+)?){1,31})(?:day\s+)?(?:in\s+)?(?:of\s+)#{MONTH_OF_YEAR}\s*(#{YEAR})?/) do |m1,m2,m3|
         month_str = (ZDate.months_of_year.index(m2) + 1).to_s
         if m3
           m1.gsub(/\b(and|the)\b|#{DAY_OF_WEEK}/,'').gsub(/#{DATE_DD_NB_ON_SUFFIX}/, month_str + '/\1/' + m3)
-        else                                                 
+        else
           m1.gsub(/\b(and|the)\b|#{DAY_OF_WEEK}/,'').gsub(/#{DATE_DD_NB_ON_SUFFIX}/, month_str + '/\1')
         end
       end
@@ -713,40 +713,40 @@ module Nickel
         month_str = (ZDate.months_of_year.index(m1) + 1).to_s
         m2.gsub(/\b(and|the)\b/,'').gsub(/#{DATE_DD_NB_ON_SUFFIX}/, month_str + '/\1/' + m3)
       end
-      
+
       nsub!(/(?:(?:#{DAY_OF_WEEK_NB}\s+(?:and\s+)?){1,7})?#{MONTH_OF_YEAR}\s+((?:(?:the\s+)?#{DATE_DD_WITHOUT_SUFFIX_NB}\s+(?:and\s+)?){1,31})#{YEAR}/) do |m1,m2,m3|
         month_str = (ZDate.months_of_year.index(m1) + 1).to_s
         m2.gsub(/\b(and|the)\b/,'').gsub(/#{DATE_DD_WITHOUT_SUFFIX}/, month_str + '/\1/' + m3)
       end
-      
-      # Dec 2nd, 3rd, and 4th  =>  12/2, 12/3, 12/4                                                                                                
+
+      # Dec 2nd, 3rd, and 4th  =>  12/2, 12/3, 12/4
       # Note: dec 5 9 to 5 will give an error, need to find these and convert to dec 5 from 9 to 5; also dec 3,4, 9 to|through 5 --> dec 3, 4 from 9 through 5
       nsub!(/(?:(?:#{DAY_OF_WEEK_NB}\s+(?:and\s+)?){1,7})?#{MONTH_OF_YEAR}\s+(?:the\s+)?((?:#{DATE_DD_WITH_SUFFIX_NB}\s+(?:and\s+)?(?:the\s+)?){1,31})/) do |m1,m2|
-        month_str = (ZDate.months_of_year.index(m1) + 1).to_s                                                                                        
+        month_str = (ZDate.months_of_year.index(m1) + 1).to_s
         m2.gsub(/(and|the)/,'').gsub(/#{DATE_DD_NB_ON_SUFFIX}/) {month_str + '/' + $1}  # that $1 is from the nested match!
       end
-      
+
       # jan 4 2-3 has to be modified, but
       # jan 24 through jan 26 cannot!
       # not real sure what this one is doing
-      # "dec 2, 3, and 4" --> 12/2, 12/3, 12/4       
-      # "mon, tue, wed, dec 2, 3, and 4" --> 12/2, 12/3, 12/4       
+      # "dec 2, 3, and 4" --> 12/2, 12/3, 12/4
+      # "mon, tue, wed, dec 2, 3, and 4" --> 12/2, 12/3, 12/4
       nsub!(/(#{MONTH_OF_YEAR_NB}\s+(?:the\s+)?(?:(?:#{DATE_DD_WITHOUT_SUFFIX_NB}\s+(?:and\s+)?(?:the\s+)?){1,31})(?:to|through|until)\s+#{DATE_DD_WITHOUT_SUFFIX_NB})/) { |m1| m1.gsub(/#{DATE_DD_WITHOUT_SUFFIX}\s+(to|through|until)/, 'from \1 through ') }
       nsub!(/(?:(?:#{DAY_OF_WEEK_NB}\s+(?:and\s+)?){1,7})?#{MONTH_OF_YEAR}\s+(?:the\s+)?((?:#{DATE_DD_WITHOUT_SUFFIX_NB}\s+(?:and\s+)?(?:the\s+)?){1,31})/) do |m1,m2|
-        month_str = (ZDate.months_of_year.index(m1) + 1).to_s                                                                                        
+        month_str = (ZDate.months_of_year.index(m1) + 1).to_s
         m2.gsub(/(and|the)/,'').gsub(/#{DATE_DD_NB_ON_SUFFIX}/) {month_str + '/' + $1}  # $1 from nested match
       end
-      
+
       # "monday 12/6" --> 12/6
       nsub!(/#{DAY_OF_WEEK_NB}\s+(#{DATE_MM_SLASH_DD})/,'\1')
-      
+
       # "next friday to|until|through the following tuesday" --> 10/12 through 10/16
       # "next friday through sunday" --> 10/12 through 10/14
       # "next friday and the following sunday" --> 11/16 11/18
       # we are not going to do date calculations here anymore, so instead:
       # next friday to|until|through the following tuesday" --> next friday through tuesday
       # next friday and the following sunday --> next friday and sunday
-      nsub!(/next\s+#{DAY_OF_WEEK}\s+(to|until|through|and)\s+(?:the\s+)?(?:following|next)?(?:\s+)?#{DAY_OF_WEEK}/) do |m1,m2,m3|
+      nsub!(/next\s+#{DAY_OF_WEEK}\s+(to|until|through|and)\s+(?:the\s+)?(?:following|next)?(?:\s)*#{DAY_OF_WEEK}/) do |m1,m2,m3|
         connector = (m2 =~ /and/ ? ' ' : ' through ')
         "next " + m1 + connector + m3
       end
@@ -757,42 +757,42 @@ module Nickel
       # No longer performing date calculation
       # this friday and the following monday --> fri mon
       # this friday through the following tuesday --> fri through tues
-      nsub!(/(?:this\s+)?#{DAY_OF_WEEK}\s+(to|until|through|and)\s+(?:the\s+)?(?:this|following)(?:\s+)?#{DAY_OF_WEEK}/) do |m1,m2,m3|
+      nsub!(/(?:this\s+)?#{DAY_OF_WEEK}\s+(to|until|through|and)\s+(?:the\s+)?(?:this|following)(?:\s)*#{DAY_OF_WEEK}/) do |m1,m2,m3|
         connector = (m2 =~ /and/ ? ' ' : ' through ')
         m1 + connector + m3
       end
-      
+
       # "the wed after next" --> 2 wed from today
       nsub!(/(?:the\s+)?#{DAY_OF_WEEK}\s+(?:after|following)\s+(?:the\s+)?next/,'2 \1 from today')
-      
+
       # "mon and tue" --> mon tue
       nsub!(/(#{DAY_OF_WEEK}\s+and\s+#{DAY_OF_WEEK})(?:\s+and)?/,'\2 \3')
-      
+
       # "mon wed every week" --> every mon wed
-      nsub!(/((#{DAY_OF_WEEK}(?:\s+)?){1,7})(?:of\s+)?(?:every|each)(\s+other)?\s+week/,'every \4 \1')
-      
+      nsub!(/((#{DAY_OF_WEEK}(?:\s)*){1,7})(?:of\s+)?(?:every|each)(\s+other)?\s+week/,'every \4 \1')
+
       # "every 2|3 weeks" --> every 2nd|3rd week
       nsub!(/(?:repeats\s+)?every\s+(2|3)\s+weeks/) {|m1| "every " + m1.to_i.ordinalize + " week"}
-      
+
       # "every week on mon tue fri" --> every mon tue fri
       nsub!(/(?:repeats\s+)?every\s+(?:(other|3rd|2nd)\s+)?weeks?\s+(?:\bon\s+)?((?:#{DAY_OF_WEEK_NB}\s+){1,7})/,'every \1 \2')
-      
+
       # "every mon and every tue and.... " --> every mon tue ...
       nsub!(/every\s+#{DAY_OF_WEEK}\s+(?:and\s+)?every\s+#{DAY_OF_WEEK}(?:\s+(?:and\s+)?every\s+#{DAY_OF_WEEK})?(?:\s+(?:and\s+)?every\s+#{DAY_OF_WEEK})?(?:\s+(?:and\s+)?every\s+#{DAY_OF_WEEK})?/,'every \1 \2 \3 \4 \5')
-      
+
       # monday, wednesday, and friday next week at 8
       nsub!(/((?:#{DAY_OF_WEEK_NB}\s+(?:and\s+)?){1,7})(?:of\s+)?(this|next)\s+week/, '\2 \1')
-      
+
       # "every day this|next week"  --> returns monday through friday of the closest week, kinda stupid
       # doesn't do that anymore, no date calculations allowed here, instead just formats it nicely for construct finders --> every day this|next week
       nsub!(/every\s+day\s+(?:of\s+)?(this|the|next)\s+week\b./) {|m1| m1 == 'next' ? "every day next week" : "every day this week"}
-      
+
       # "every day for the next week" --> "every day this week"
       nsub!(/every\s+day\s+for\s+(the\s+)?(next|this)\s+week/, 'every day this week')
-      
+
       # "this weekend" --> sat sun
       nsub!(/(every\s+day\s+|both\s+days\s+)?this\s+weekend(\s+on)?(\s+both\s+days|\s+every\s+day|\s+sat\s+sun)?/,'sat sun')
-      
+
       # "this weekend including mon" --> sat sun mon
       nsub!(/sat\s+sun\s+(and|includ(es?|ing))\s+mon/,'sat sun mon')
       nsub!(/sat\s+sun\s+(and|includ(es?|ing))\s+fri/,'fri sat sun')
@@ -800,17 +800,17 @@ module Nickel
       # Note: next weekend including monday will now fail.  Need to make constructors find "next sat sun mon"
       # "next weekend" --> next weekend
       nsub!(/(every\s+day\s+|both\s+days\s+)?next\s+weekend(\s+on)?(\s+both\s+days|\s+every\s+day|\s+sat\s+sun)?/,'next weekend')
-      
+
       # "next weekend including mon" --> next sat sun mon
       nsub!(/next\s+weekend\s+(and|includ(es?|ing))\s+mon/,'next sat sun mon')
       nsub!(/next\s+weekend\s+(and|includ(es?|ing))\s+fri/,'next fri sat sun')
-      
+
       # "every weekend" --> every sat sun
       nsub!(/every\s+weekend(?:\s+(?:and|includ(?:es?|ing))\s+(mon|fri))?/,'every sat sun' + ' \1')  # regarding "every sat sun fri", order should not matter after "every" keyword
-      
+
       # "weekend" --> sat sun     !!! catch all
       nsub!(/weekend/,'sat sun')
-      
+
       # "mon through wed" -- >  mon tue wed
       # CATCH ALL FOR SPANS, TRY NOT TO USE THIS
       nsub!(/#{DAY_OF_WEEK}\s+(?:through|to|until)\s+#{DAY_OF_WEEK}/) do |m1,m2|
@@ -835,18 +835,18 @@ module Nickel
             i = (i + 1) % 7
           end
         end
-        ret_string      
+        ret_string
       end
-      
+
       # "every day" --> repeats daily
       nsub!(/\b(repeat(?:s|ing)?|every|each)\s+da(ily|y)\b/,'repeats daily')
-      
+
       # "every other week starting this|next fri" --> every other friday starting this friday
       nsub!(/every\s+(3rd|other)\s+week\s+(?:start(?:s|ing)?|begin(?:s|ning)?)\s+(this|next)\s+#{DAY_OF_WEEK}/,'every \1 \3 start \2 \3')
-      
+
       # "every other|3rd friday starting this|next week" --> every other|3rd friday starting this|next friday
       nsub!(/every\s+(3rd|other)\s+#{DAY_OF_WEEK}\s+(?:start(?:s|ing)?|begin(?:s|ning)?)\s+(this|next)\s+week/,'every \1 \2 start \3 \2')
-      
+
       # "repeats monthly on the 1st and 2nd friday" --> repeats monthly 1st friday 2nd friday
       # "repeats every other month on the 1st and 2nd friday" --> repeats monthly 1st friday 2nd friday
       # "repeats every three months on the 1st and 2nd friday" --> repeats threemonthly 1st friday 2nd friday
@@ -856,7 +856,7 @@ module Nickel
       nsub!(/(?:repeats\s+)?(?:(?:each|every|all)\s+)\bmonth(?:ly|s)?\s+(?:\bon\s+)?(?:the\s+)?((?:(?:1st|2nd|3rd|4th|5th)\s+(?:and\s+)?(?:the\s+)?){2,5})#{DAY_OF_WEEK}/)          { |m1,m2| "repeats monthly " + m1.gsub(/\b(and|the)\b/,'').split.join(" " + m2 + " ") + " " + m2 + " " }
       nsub!(/(?:repeats\s+)?(?:(?:each|every|all)\s+)(?:other|2n?d?)\s+months?\s+(?:\bon\s+)?(?:the\s+)?((?:(?:1st|2nd|3rd|4th|5th)\s+(?:and\s+)?(?:the\s+)?){2,5})#{DAY_OF_WEEK}/) { |m1,m2| "repeats altmonthly " + m1.gsub(/\b(and|the)\b/,'').split.join(" " + m2 + " ") + " " + m2 + " " }
       nsub!(/(?:repeats\s+)?(?:(?:each|every|all)\s+)3r?d?\s+months?\s+(?:\bon\s+)?(?:the\s+)?((?:(?:1st|2nd|3rd|4th|5th)\s+(?:and\s+)?(?:the\s+)?){2,5})#{DAY_OF_WEEK}/)           { |m1,m2| "repeats threemonthly " + m1.gsub(/\b(and|the)\b/,'').split.join(" " + m2 + " ") + " " + m2 + " " }
-      
+
       # "repeats monthly on the 1st friday" --> repeats monthly 1st friday
       # "repeats monthly on the 1st friday, second tuesday, and third friday" --> repeats monthly 1st friday 2nd tuesday 3rd friday
       # "repeats every other month on the 1st friday, second tuesday, and third friday" --> repeats monthly 1st friday 2nd tuesday 3rd friday
@@ -866,7 +866,7 @@ module Nickel
       nsub!(/(?:repeats\s+)?(?:(?:each|every|all)\s+)\bmonth(?:ly|s)?\s+(?:\bon\s+)?(?:the\s+)?((?:(?:1|2|3|4|5)(?:st|nd|rd|th)?\s+#{DAY_OF_WEEK_NB}\s+(?:and\s+)?(?:the\s+)?){1,31})/)                 { |m1| "repeats monthly " + m1.gsub(/\b(and|the)\b/,'') + " "}
       nsub!(/(?:repeats\s+)?(?:(?:each|every|all)\s+)(?:other|2n?d?)\s+month(?:ly|s)?\s+(?:\bon\s+)?(?:the\s+)?((?:(?:1|2|3|4|5)(?:st|nd|rd|th)?\s+#{DAY_OF_WEEK_NB}\s+(?:and\s+)?(?:the\s+)?){1,31})/) { |m1| "repeats altmonthly " + m1.gsub(/\b(and|the)\b/,'') + " "}
       nsub!(/(?:repeats\s+)?(?:(?:each|every|all)\s+)3r?d?\s+month(?:ly|s)?\s+(?:\bon\s+)?(?:the\s+)?((?:(?:1|2|3|4|5)(?:st|nd|rd|th)?\s+#{DAY_OF_WEEK_NB}\s+(?:and\s+)?(?:the\s+)?){1,31})/)           { |m1| "repeats threemonthly " + m1.gsub(/\b(and|the)\b/,'') + " "}
-      
+
       # "repeats monthly on the 1st friday saturday" --> repeats monthly 1st friday 1st saturday
       nsub!(/(?:repeats\s+)(?:(?:each|every|all)\s+)?\bmonth(?:ly|s)?\s+(?:\bon\s+)?(?:the\s+)?(1st|2nd|3rd|4th|5th)\s+((?:#{DAY_OF_WEEK_NB}\s+){2,7})/)                  { |m1,m2| "repeats monthly " + m1 + " " + m2.split.join(" " + m1 + " ") + " "}
       nsub!(/(?:repeats\s+)(?:(?:each|every|all)\s+)?(?:other|2n?d?)\s+month(?:ly|s)?\s+(?:\bon\s+)?(?:the\s+)?(1st|2nd|3rd|4th|5th)\s+((?:#{DAY_OF_WEEK_NB}\s+){2,7})/)  { |m1,m2| "repeats altmonthly " + m1 + " " + m2.split.join(" " + m1 + " ") + " "}
@@ -874,13 +874,13 @@ module Nickel
       nsub!(/(?:repeats\s+)?(?:(?:each|every|all)\s+)\bmonth(?:ly|s)?\s+(?:\bon\s+)?(?:the\s+)?(1st|2nd|3rd|4th|5th)\s+((?:#{DAY_OF_WEEK_NB}\s+){2,7})/)                  { |m1,m2| "repeats monthly " + m1 + " " + m2.split.join(" " + m1 + " ") + " "}
       nsub!(/(?:repeats\s+)?(?:(?:each|every|all)\s+)(?:other|2n?d?)\s+month(?:ly|s)?\s+(?:\bon\s+)?(?:the\s+)?(1st|2nd|3rd|4th|5th)\s+((?:#{DAY_OF_WEEK_NB}\s+){2,7})/)  { |m1,m2| "repeats altmonthly " + m1 + " " + m2.split.join(" " + m1 + " ") + " "}
       nsub!(/(?:repeats\s+)?(?:(?:each|every|all)\s+)3r?d?\s+month(?:ly|s)?\s+(?:\bon\s+)?(?:the\s+)?(1st|2nd|3rd|4th|5th)\s+((?:#{DAY_OF_WEEK_NB}\s+){2,7})/)            { |m1,m2| "repeats threemonthly " + m1 + " " + m2.split.join(" " + m1 + " ") + " "}
-      
+
       # "21st of each month" --> repeats monthly 21st
       # "on the 21st, 22nd and 25th of each month" --> repeats monthly 21st 22nd 25th
       nsub!(/(?:repeats\s+)?(?:\bon\s+)?(?:the\s+)?((?:#{DATE_DD_WITH_SUFFIX_NB}\s+(?:and\s+)?(?:the\s+)?){1,31})(?:days?\s+)?(?:of\s+)?(?:each|all|every)\s+\bmonths?/)                  { |m1| "repeats monthly " + m1.gsub(/\b(and|the)\b/,'') + " "}
       nsub!(/(?:repeats\s+)?(?:\bon\s+)?(?:the\s+)?((?:#{DATE_DD_WITH_SUFFIX_NB}\s+(?:and\s+)?(?:the\s+)?){1,31})(?:days?\s+)?(?:of\s+)?(?:each|all|every)\s+(?:other|2n?d?)\s+months?/)  { |m1| "repeats altmonthly " + m1.gsub(/\b(and|the)\b/,'') + " "}
       nsub!(/(?:repeats\s+)?(?:\bon\s+)?(?:the\s+)?((?:#{DATE_DD_WITH_SUFFIX_NB}\s+(?:and\s+)?(?:the\s+)?){1,31})(?:days?\s+)?(?:of\s+)?(?:each|all|every)\s+3r?d?\s+months?/)            { |m1| "repeats threemonthly " + m1.gsub(/\b(and|the)\b/,'') + " "}
-      
+
       # "repeats each month on the 22nd" --> repeats monthly 22nd
       # "repeats monthly on the 22nd 23rd and 24th" --> repeats monthly 22nd 23rd 24th
       # This can ONLY handle multi-day recurrence WITHOUT independent times for each, i.e. "repeats monthly on the 22nd at noon and 24th from 1 to 9"  won't work; that's going to be a tricky one.
@@ -894,71 +894,71 @@ module Nickel
       nsub!(/(?:repeats\s+)?(?:(?:each|every|all)\s+)3r?d?\s+month(?:s|ly)?\s+(?:on\s+)?(?:the\s+)?((?:#{DATE_DD_NB}\s+(?:and\s+)?(?:the\s+)?){1,10})/)  { |m1| "repeats threemonthly " + m1.gsub(/\b(and|the)\b/,'') + " " }
       nsub!(/(?:repeats\s+)(?:(?:each|every|all)\s+)?3r?d?\s+month(?:s|ly)?\s+(?:on\s+)?(?:the\s+)?((?:#{DATE_DD_NB}\s+(?:and\s+)?(?:the\s+)?){1,10})/)  { |m1| "repeats threemonthly " + m1.gsub(/\b(and|the)\b/,'') + " "}
      #nsub!(/(?:repeats\s+)?(?:(?:each|every|all)\s+)?3r?d?\s+month(?:s|ly)\s+(?:on\s+)?(?:the\s+)?((?:#{DATE_DD_NB}\s+(?:and\s+)?(?:the\s+)?){1,10})/)  { |m1| "repeats threemonthly " + m1.gsub(/\b(and|the)\b/,'') + " "}
-     
+
       # "on day 4 of every month" --> repeats monthly 4
       # "on days 4 9 and 14 of every month" --> repeats monthly 4 9 14
       nsub!(/(?:repeats\s+)?(?:\bon\s+)?(?:day|date)s?\s+((?:#{DATE_DD_NB}\s+(?:and\s+)?(?:the\s+)?){1,10})(?:of\s+)(every|all|each)\s+\bmonths?/) { |m1| "repeats monthly " + m1.gsub(/\b(and|the)\b/,'') + " " }
       nsub!(/(?:repeats\s+)?(?:\bon\s+)?(?:day|date)s?\s+((?:#{DATE_DD_NB}\s+(?:and\s+)?(?:the\s+)?){1,10})(?:of\s+)(every|all|each)\s+(?:other|2n?d?)\s+months?/) { |m1| "repeats altmonthly " + m1.gsub(/\b(and|the)\b/,'') + " " }
       nsub!(/(?:repeats\s+)?(?:\bon\s+)?(?:day|date)s?\s+((?:#{DATE_DD_NB}\s+(?:and\s+)?(?:the\s+)?){1,10})(?:of\s+)(every|all|each)\s+3r?d?\s+months?/) { |m1| "repeats threemonthly " + m1.gsub(/\b(and|the)\b/,'') + " " }
-      
+
       # "every 22nd of the month" --> repeats monthly 22
       # "every 22nd 23rd and 25th of the month" --> repeats monthly 22 23 25
       nsub!(/(?:repeats\s+)?(?:every|each)\s+((?:#{DATE_DD_WITH_SUFFIX_NB}\s+(?:and\s+)?(?:the\s+)?){1,10})(?:day\s+)?(?:of\s+)?(?:the\s+)?\bmonth/) { |m1| "repeats monthly " + m1.gsub(/\b(and|the)\b/,'') + " "}
       nsub!(/(?:repeats\s+)?(?:every|each)\s+other\s+((?:#{DATE_DD_WITH_SUFFIX_NB}\s+(?:and\s+)?(?:the\s+)?){1,10})(?:day\s+)?(?:of\s+)?(?:the\s+)?\bmonth/) { |m1| "repeats altmonthly " + m1.gsub(/\b(and|the)\b/,'') + " "}
-      
+
       # "every 1st and 2nd fri of the month" --> repeats monthly 1st fri 2nd fri
       nsub!(/(?:repeats\s+)?(?:each|every|all)\s+((?:(?:1st|2nd|3rd|4th|5th)\s+(?:and\s+)?(?:the\s+)?){2,5})#{DAY_OF_WEEK}\s+(?:of\s+)?(?:the\s+)?(?:(?:each|every|all)\s+)?\bmonths?/) { |m1,m2| "repeats monthly " + m1.gsub(/\b(and|the)\b/,'').split.join(" " + m2 + " ") + " " + m2 + " " }
       nsub!(/(?:repeats\s+)?(?:each|every|all)\s+other\s+((?:(?:1st|2nd|3rd|4th|5th)\s+(?:and\s+)?(?:the\s+)?){2,5})#{DAY_OF_WEEK}\s+(?:of\s+)?(?:the\s+)?(?:(?:each|every|all)\s+)?\bmonths?/) { |m1,m2| "repeats altmonthly " + m1.gsub(/\b(and|the)\b/,'').split.join(" " + m2 + " ") + " " + m2 + " " }
-      
+
       # "every 1st friday of the month" --> repeats monthly 1st friday
       # "every 1st friday and 2nd tuesday of the month" --> repeats monthly 1st friday 2nd tuesday
       nsub!(/(?:repeats\s+)?(?:each|every|all)\s+((?:(?:1|2|3|4|5)(?:st|nd|rd|th)?\s+#{DAY_OF_WEEK_NB}\s+(?:and\s+)?(?:the\s+)?){1,10})(?:of\s+)?(?:the\s+)?(?:(?:each|every|all)\s+)?\bmonths?/)  { |m1| "repeats monthly " + m1.gsub(/\b(and|the)\b/,'') + " "}
       nsub!(/(?:repeats\s+)?(?:each|every|all)\s+other\s+((?:(?:1|2|3|4|5)(?:st|nd|rd|th)?\s+#{DAY_OF_WEEK_NB}\s+(?:and\s+)?(?:the\s+)?){1,10})(?:of\s+)?(?:the\s+)?(?:(?:each|every|all)\s+)?\bmonths?/)  { |m1| "repeats altmonthly " + m1.gsub(/\b(and|the)\b/,'') + " "}
-      
+
       # "every 1st fri sat of the month" --> repeats monthly 1st fri 1st sat
       nsub!(/(?:repeats\s+)?(?:each|every|all)\s+(1st|2nd|3rd|4th|5th)\s+((?:#{DAY_OF_WEEK_NB}\s+){2,7})(?:of\s+)?(?:the\s+)?(?:(?:each|every|all)\s+)?\bmonths?/)          { |m1,m2| "repeats monthly " + m1 + " " + m2.split.join(" " + m1 + " ") + " "}
       nsub!(/(?:repeats\s+)?(?:each|every|all)\s+other\s+(1st|2nd|3rd|4th|5th)\s+((?:#{DAY_OF_WEEK_NB}\s+){2,7})(?:of\s+)?(?:the\s+)?(?:(?:each|every|all)\s+)?\bmonths?/)  { |m1,m2| "repeats altmonthly " + m1 + " " + m2.split.join(" " + m1 + " ") + " "}
-      
+
       # "the 1st and 2nd friday of every month" --> repeats monthly 1st friday 2nd friday
       nsub!(/(?:repeats\s+)?(?:\bon\s+)?(?:the\s+)?((?:(?:1st|2nd|3rd|4th|5th)\s+(?:and\s+)?(?:the\s+)?){2,5})#{DAY_OF_WEEK}\s+(?:of\s+)?(?:(?:every|each|all)\s+)\bmonths?/)                 { |m1,m2| "repeats monthly " +  m1.gsub(/\b(and|the)\b/,'').split.join(" " + m2 + " ") + " " + m2 + " " }
       nsub!(/(?:repeats\s+)?(?:\bon\s+)?(?:the\s+)?((?:(?:1st|2nd|3rd|4th|5th)\s+(?:and\s+)?(?:the\s+)?){2,5})#{DAY_OF_WEEK}\s+(?:of\s+)?(?:(?:every|each|all)\s+)(?:other|2n?d?)\s+months?/) { |m1,m2| "repeats altmonthly " +  m1.gsub(/\b(and|the)\b/,'').split.join(" " + m2 + " ") + " " + m2 + " " }
       nsub!(/(?:repeats\s+)?(?:\bon\s+)?(?:the\s+)?((?:(?:1st|2nd|3rd|4th|5th)\s+(?:and\s+)?(?:the\s+)?){2,5})#{DAY_OF_WEEK}\s+(?:of\s+)?(?:(?:every|each|all)\s+)3r?d?\s+months?/)           { |m1,m2| "repeats threemonthly " +  m1.gsub(/\b(and|the)\b/,'').split.join(" " + m2 + " ") + " " + m2 + " " }
-      
+
       # "the 1st friday of every month" --> repeats monthly 1st friday
       # "the 1st friday and the 2nd tuesday of every month" --> repeats monthly 1st friday 2nd tuesday
       nsub!(/(?:repeats\s+)?(?:\bon\s+)?(?:the\s+)?((?:(?:1|2|3|4|5)(?:st|nd|rd|th)?\s+#{DAY_OF_WEEK_NB}\s+(?:and\s+)?(?:the\s+)?){1,10})(?:of\s+)?(?:(?:every|each|all)\s+)\bmonths?/)                   { |m1| "repeats monthly " + m1.gsub(/\b(and|the)\b/,'') + " "}
       nsub!(/(?:repeats\s+)?(?:\bon\s+)?(?:the\s+)?((?:(?:1|2|3|4|5)(?:st|nd|rd|th)?\s+#{DAY_OF_WEEK_NB}\s+(?:and\s+)?(?:the\s+)?){1,10})(?:of\s+)?(?:(?:every|each|all)\s+)(?:other|2n?d?)\s+months?/)   { |m1| "repeats altmonthly " + m1.gsub(/\b(and|the)\b/,'') + " "}
       nsub!(/(?:repeats\s+)?(?:\bon\s+)?(?:the\s+)?((?:(?:1|2|3|4|5)(?:st|nd|rd|th)?\s+#{DAY_OF_WEEK_NB}\s+(?:and\s+)?(?:the\s+)?){1,10})(?:of\s+)?(?:(?:every|each|all)\s+)3r?d?\s+months?/)             { |m1| "repeats threemonthly " + m1.gsub(/\b(and|the)\b/,'') + " "}
-      
+
       # "the 1st friday saturday of every month" --> repeats monthly 1st friday 1st saturday
       nsub!(/(?:repeats\s+)?(?:\bon\s+)?(?:the\s+)?(1st|2nd|3rd|4th|5th)\s+((?:#{DAY_OF_WEEK_NB}\s+){2,7})(?:of\s+)?(?:(?:every|each|all)\s+)\bmonths?/)                  { |m1,m2| "repeats monthly " + m1 + " " + m2.split.join(" " + m1 + " ") + " "}
       nsub!(/(?:repeats\s+)?(?:\bon\s+)?(?:the\s+)?(1st|2nd|3rd|4th|5th)\s+((?:#{DAY_OF_WEEK_NB}\s+){2,7})(?:of\s+)?(?:(?:every|each|all)\s+)(?:other|2n?d?)\s+months?/)  { |m1,m2| "repeats altmonthly " + m1 + " " + m2.split.join(" " + m1 + " ") + " "}
       nsub!(/(?:repeats\s+)?(?:\bon\s+)?(?:the\s+)?(1st|2nd|3rd|4th|5th)\s+((?:#{DAY_OF_WEEK_NB}\s+){2,7})(?:of\s+)?(?:(?:every|each|all)\s+)3r?d?\s+months?/)            { |m1,m2| "repeats threemonthly " + m1 + " " + m2.split.join(" " + m1 + " ") + " "}
-      
+
       # "repeats on the 1st and second friday of the month" --> repeats monthly 1st friday 2nd friday
       nsub!(/(?:repeats\s+)(?:\bon\s+)?(?:the\s+)?((?:(?:1st|2nd|3rd|4th|5th)\s+(?:and\s+)?(?:the\s+)?){2,5})#{DAY_OF_WEEK}\s+(?:of\s+)?(?:(?:every|each|all|the)\s+)?\bmonths?/)                 { |m1,m2| "repeats monthly " +  m1.gsub(/\b(and|the)\b/,'').split.join(" " + m2 + " ") + " " + m2 + " " }
       nsub!(/(?:repeats\s+)(?:\bon\s+)?(?:the\s+)?((?:(?:1st|2nd|3rd|4th|5th)\s+(?:and\s+)?(?:the\s+)?){2,5})#{DAY_OF_WEEK}\s+(?:of\s+)?(?:(?:every|each|all|the)\s+)?(?:other|2n?d?)\s+months?/) { |m1,m2| "repeats altmonthly " +  m1.gsub(/\b(and|the)\b/,'').split.join(" " + m2 + " ") + " " + m2 + " " }
       nsub!(/(?:repeats\s+)(?:\bon\s+)?(?:the\s+)?((?:(?:1st|2nd|3rd|4th|5th)\s+(?:and\s+)?(?:the\s+)?){2,5})#{DAY_OF_WEEK}\s+(?:of\s+)?(?:(?:every|each|all|the)\s+)?3r?d?\s+months?/)           { |m1,m2| "repeats threemonthly " +  m1.gsub(/\b(and|the)\b/,'').split.join(" " + m2 + " ") + " " + m2 + " " }
-      
+
       # "repeats on the 1st friday of the month --> repeats monthly 1st friday
       # "repeats on the 1st friday and second tuesday of the month" --> repeats monthly 1st friday 2nd tuesday
       nsub!(/(?:repeats\s+)(?:\bon\s+)?(?:the\s+)?((?:(?:1|2|3|4|5)(?:st|nd|rd|th)?\s+#{DAY_OF_WEEK_NB}\s+(?:and\s+)?(?:the\s+)?){1,10})(?:of\s+)?(?:(?:every|each|all|the)\s+)?\bmonths?/)                   { |m1| "repeats monthly " + m1.gsub(/\b(and|the)\b/,'') + " "}
       nsub!(/(?:repeats\s+)(?:\bon\s+)?(?:the\s+)?((?:(?:1|2|3|4|5)(?:st|nd|rd|th)?\s+#{DAY_OF_WEEK_NB}\s+(?:and\s+)?(?:the\s+)?){1,10})(?:of\s+)?(?:(?:every|each|all|the)\s+)?(?:other|2n?d?)\s+months?/)   { |m1| "repeats altmonthly " + m1.gsub(/\b(and|the)\b/,'') + " "}
       nsub!(/(?:repeats\s+)(?:\bon\s+)?(?:the\s+)?((?:(?:1|2|3|4|5)(?:st|nd|rd|th)?\s+#{DAY_OF_WEEK_NB}\s+(?:and\s+)?(?:the\s+)?){1,10})(?:of\s+)?(?:(?:every|each|all|the)\s+)?3r?d?\s+months?/)             { |m1| "repeats threemonthly " + m1.gsub(/\b(and|the)\b/,'') + " "}
-      
+
       # "repeats on the 1st friday saturday of the month" --> repeats monthly 1st friday 1st saturday
       nsub!(/(?:repeats\s+)(?:\bon\s+)?(?:the\s+)?(1st|2nd|3rd|4th|5th)\s+((?:#{DAY_OF_WEEK_NB}\s+){2,7})(?:of\s+)?(?:(?:every|each|all|the)\s+)?\bmonths?/)                  { |m1,m2| "repeats monthly " + m1 + " " + m2.split.join(" " + m1 + " ") + " "}
       nsub!(/(?:repeats\s+)(?:\bon\s+)?(?:the\s+)?(1st|2nd|3rd|4th|5th)\s+((?:#{DAY_OF_WEEK_NB}\s+){2,7})(?:of\s+)?(?:(?:every|each|all|the)\s+)?(?:other|2n?d?)\s+months?/)  { |m1,m2| "repeats altmonthly " + m1 + " " + m2.split.join(" " + m1 + " ") + " "}
       nsub!(/(?:repeats\s+)(?:\bon\s+)?(?:the\s+)?(1st|2nd|3rd|4th|5th)\s+((?:#{DAY_OF_WEEK_NB}\s+){2,7})(?:of\s+)?(?:(?:every|each|all|the)\s+)?3r?d?\s+months?/)            { |m1,m2| "repeats threemonthly " + m1 + " " + m2.split.join(" " + m1 + " ") + " "}
-      
+
       # "repeats each month" --> every month
       nsub!(/(repeats\s+)?(each|every)\s+\bmonth(ly)?/,'every month ')
       nsub!(/all\s+months/,'every month')
-      
-      # "repeats every other month" --> every other month    
+
+      # "repeats every other month" --> every other month
       nsub!(/(repeats\s+)?(each|every)\s+(other|2n?d?)\s+month(ly)?/,'every other month ')
       nsub!(/(repeats\s+)?bimonthly/,'every other month ')    # hyphens have already been replaced in spell check (bi-monthly)
-      
+
       # "repeats every three months" --> every third month
       nsub!(/(repeats\s+)?(each|every)\s+3r?d?\s+month/,'every third month ')
       nsub!(/(repeats\s+)?trimonthly/,'every third month ')
@@ -966,29 +966,29 @@ module Nickel
       # All months
       nsub!(/(repeats\s+)?all\s+months/,'every month ')
       nsub!(/(repeats\s+)?all\s+other\+months/, 'every other month ')
-      
+
       # All month
       nsub!(/all\s+month/, 'this month ')
       nsub!(/all\s+next\s+month/, 'next month ')
-      
+
       # "repeats 2nd mon" --> repeats monthly 2nd mon
       # "repeats 2nd mon, 3rd fri, and the last sunday" --> repeats monthly 2nd mon 3rd fri 5th sun
       nsub!(/repeats\s+(?:\bon\s+)?(?:the\s+)?((?:(?:1|2|3|4|5)(?:st|nd|rd|th)?\s+#{DAY_OF_WEEK_NB}\s+(?:and\s+)?(?:the\s+)?){1,10})/) { |m1| "repeats monthly " + m1.gsub(/\b(and|the)\b/,'') + " "}
-      
+
       # "starting at x, ending at y" --> from x to y
       nsub!(/(?:begin|start)(?:s|ing|ning)?\s+(?:at\s+)?#{TIME}\s+(?:and\s+)?end(?:s|ing)?\s+(?:at\s+)#{TIME}/,'from \1 to \2')
-      
+
       # "the x through the y"
       nsub!(/^(?:the\s+)?#{DATE_DD_WITH_SUFFIX}\s+(?:through|to|until)\s+(?:the\s+)?#{DATE_DD_WITH_SUFFIX}$/,'\1 through \2 ')
-      
+
       # "x week(s) away" --> x week(s) from now
       nsub!(/([0-9]+)\s+(day|week|month)s?\s+away/,'\1 \2s from now')
-      
+
       # "x days from now" --> "x days from now"
       # "in 2 weeks|days|months" --> 2 days|weeks|months from now"
       nsub!(/\b(an?|[0-9]+)\s+(day|week|month)s?\s+(?:from\s+now|away)/, '\1 \2 from now')
       nsub!(/in\s+(a|[0-9]+)\s+(week|day|month)s?/, '\1 \2 from now')
-      
+
       # "x minutes|hours from now" --> "in x hours|minutes"
       # "in x hour(s)" --> 11/20/07 at 22:00
       # REDONE, no more calculations
@@ -996,10 +996,10 @@ module Nickel
       # "in x hours|minutes --> x hours|minutes from now"
       nsub!(/\b(an?|[0-9]+)\s+(hour|minute)s?\s+(?:from\s+now|away)/, '\1 \2 from now')
       nsub!(/in\s+(an?|[0-9]+)\s+(hour|minute)s?/, '\1 \2 from now')
-      
+
       # Now only
-      nsub!(/^(?:\s+)?(?:right\s+)?now(?:\s+)?$/, '0 minutes from now')
-      
+      nsub!(/^(?:\s)*(?:right\s+)?now(?:\s)*$/, '0 minutes from now')
+
       # "a week/month from yesterday|tomorrow" --> 1 week from yesterday|tomorrow
       nsub!(/(?:(?:a|1)\s+)?(week|month)\s+from\s+(yesterday|tomorrow)/,'1 \1 from \2')
 
@@ -1008,8 +1008,8 @@ module Nickel
 
       # "every 2|3 days" --> every 2nd|3rd day
       nsub!(/every\s+(2|3)\s+days?/) {|m1| "every " + m1.to_i.ordinalize + " day"}
-      
-      # "the following" --> following 
+
+      # "the following" --> following
       nsub!(/the\s+following/,'following')
 
       # "friday the 12th to sunday the 14th" --> 12th through 14th
@@ -1017,7 +1017,7 @@ module Nickel
 
       # "between 1 and 4" --> from 1 to 4
       nsub!(/between\s+#{TIME}\s+and\s+#{TIME}/,'from \1 to \2')
-      
+
       # "on the 3rd sat of this month" --> "3rd sat this month"
       # "on the 3rd sat and 5th tuesday of this month" --> "3rd sat this month 5th tuesday this month"
       # "on the 3rd sat and sunday of this month" --> "3rd sat this month 3rd sun this month"
@@ -1027,7 +1027,7 @@ module Nickel
       nsub!(/(?:\bon\s+)?(?:the\s+)?(1st|2nd|3rd|4th|5th)\s+((?:#{DAY_OF_WEEK_NB}\s+(?:and\s+)?){2,7})(?:of\s+)?(?:this|of)\s+month/)               { |m1,m2| m2.gsub(/\band\b/,'').gsub(/#{DAY_OF_WEEK}/, m1 + ' \1 this month') }
       nsub!(/(?:\bon\s+)?(?:the\s+)?((?:(?:1st|2nd|3rd|4th|5th)\s+(?:and\s+)?(?:the\s+)?){2,7})#{DAY_OF_WEEK}\s+(?:of\s+)?(?:this|of)\s+month/)     { |m1,m2| m1.gsub(/\b(and|the)\b/,'').gsub(/(1st|2nd|3rd|4th|5th)/, '\1 ' + m2 + ' this month') }
       nsub!(/(?:\bon\s+)?(?:the\s+)?((?:(?:1st|2nd|3rd|4th|5th)\s+#{DAY_OF_WEEK_NB}\s+(?:and\s+)?(?:the\s+)?){1,10})(?:of\s+)?(?:this|of)\s+month/) { |m1| m1.gsub(/\b(and|the)\b/,'').gsub(/#{DAY_OF_WEEK}/,'\1 this month') }
-      
+
       # "on the 3rd sat of next month" --> "3rd sat next month"
       # "on the 3rd sat and 5th tuesday of next month" --> "3rd sat next month 5th tuesday next month"
       # "on the 3rd sat and sunday of next month" --> "3rd sat this month 3rd sun next month"
@@ -1035,7 +1035,7 @@ module Nickel
       nsub!(/(?:\bon\s+)?(?:the\s+)?(1st|2nd|3rd|4th|5th)\s+((?:#{DAY_OF_WEEK_NB}\s+(?:and\s+)?){2,7})(?:of\s+)?next\s+month/)                { |m1,m2| m2.gsub(/\band\b/,'').gsub(/#{DAY_OF_WEEK}/, m1 + ' \1 next month') }
       nsub!(/(?:\bon\s+)?(?:the\s+)?((?:(?:1st|2nd|3rd|4th|5th)\s+(?:and\s+)?(?:the\s+)?){2,7})#{DAY_OF_WEEK}\s+(?:of\s+)?next\s+month/)      { |m1,m2| m1.gsub(/\b(and|the)\b/,'').gsub(/(1st|2nd|3rd|4th|5th)/, '\1 ' + m2 + ' next month') }
       nsub!(/(?:\bon\s+)?(?:the\s+)?((?:(?:1st|2nd|3rd|4th|5th)\s+#{DAY_OF_WEEK_NB}\s+(?:and\s+)?(?:the\s+)?){1,10})(?:of\s+)?next\s+month/)  { |m1| m1.gsub(/\b(and|the)\b/,'').gsub(/#{DAY_OF_WEEK}/,'\1 next month') }
-      
+
       # "on the 3rd sat of nov" --> "3rd sat nov"
       # "on the 3rd sat and 5th tuesday of nov" --> "3rd sat nov 5th tuesday nov            !!!!!!! walking a fine line here, 'nov 5th', but then again the entire nlp walks a pretty fine line
       # "on the 3rd sat and sunday of nov" --> "3rd sat nov 3rd sun nov"
@@ -1043,27 +1043,27 @@ module Nickel
       nsub!(/(?:\bon\s+)?(?:the\s+)?(1st|2nd|3rd|4th|5th)\s+((?:#{DAY_OF_WEEK_NB}\s+(?:and\s+)?){2,7})(?:of\s+)?(?:in\s+)?#{MONTH_OF_YEAR}/)                { |m1,m2,m3| m2.gsub(/\band\b/,'').gsub(/#{DAY_OF_WEEK}/, m1 + ' \1 ' + m3) }
       nsub!(/(?:\bon\s+)?(?:the\s+)?((?:(?:1st|2nd|3rd|4th|5th)\s+(?:and\s+)?(?:the\s+)?){2,7})#{DAY_OF_WEEK}\s+(?:of\s+)?(?:in\s+)?#{MONTH_OF_YEAR}/)      { |m1,m2,m3| m1.gsub(/\b(and|the)\b/,'').gsub(/(1st|2nd|3rd|4th|5th)/, '\1 ' + m2 + ' ' + m3) }
       nsub!(/(?:\bon\s+)?(?:the\s+)?((?:(?:1st|2nd|3rd|4th|5th)\s+#{DAY_OF_WEEK_NB}\s+(?:and\s+)?(?:the\s+)?){1,10})(?:of\s+)?(?:in\s+)?#{MONTH_OF_YEAR}/)  { |m1,m2| m1.gsub(/\b(and|the)\b/,'').gsub(/#{DAY_OF_WEEK}/,'\1 ' + m2) }
-      
+
       # "on the last day of nov" --> "last day nov"
       nsub!(/(?:\bon\s+)?(?:the\s+)?last\s+day\s+(?:of\s+)?(?:in\s+)?#{MONTH_OF_YEAR}/,'last day \1')
       # "on the 1st|last day of this|the month" --> "1st|last day this month"
-      nsub!(/(?:\bon\s+)?(?:the\s+)?(1st|last)\s+day\s+(?:of\s+)?(?:this|the)?(?:\s+)?month/,'\1 day this month')
+      nsub!(/(?:\bon\s+)?(?:the\s+)?(1st|last)\s+day\s+(?:of\s+)?(?:this|the)?(?:\s)*month/,'\1 day this month')
       # "on the 1st|last day of next month" --> "1st|last day next month"
       nsub!(/(?:\bon\s+)?(?:the\s+)?(1st|last)\s+day\s+(?:of\s+)?next\s+month/,'\1 day next month')
-      
+
       # "every other weekend" --> every other sat sun
       nsub!(/every\s+other\s+weekend/,'every other sat sun')
-      
+
       # "this week on mon "--> this mon
       nsub!(/this\s+week\s+(?:on\s+)?#{DAY_OF_WEEK}/,'this \1')
       # "mon of this week " --> this mon
       nsub!(/#{DAY_OF_WEEK}\s+(?:of\s+)?this\s+week/,'this \1')
-      
+
       # "next week on mon "--> next mon
       nsub!(/next\s+week\s+(?:on\s+)?#{DAY_OF_WEEK}/,'next \1')
       # "mon of next week " --> next mon
       nsub!(/#{DAY_OF_WEEK}\s+(?:of\s+)?next\s+week/,'next \1')
-      
+
       # Ordinal this month:
       # this will slip by now
       # the 23rd of this|the month --> 8/23
@@ -1073,7 +1073,7 @@ module Nickel
       # this month on the 23rd --> 23rd this month
       nsub!(/(?:the\s+)?#{DATE_DD}\s+(?:of\s+)?(?:this|the)\s+month/, '\1 this month')
       nsub!(/this\s+month\s+(?:(?:on|the)\s+)?(?:(?:on|the)\s+)?#{DATE_DD}/, '\1 this month')
-      
+
       # Ordinal next month:
       # this will slip by now
       # the 23rd of next month --> 9/23
@@ -1083,30 +1083,30 @@ module Nickel
       # next month on the 23rd --> 23rd next month
       nsub!(/(?:the\s+)?#{DATE_DD}\s+(?:of\s+)?(?:next|the\s+following)\s+month/, '\1 next month')
       nsub!(/(?:next|the\s+following)\s+month\s+(?:(?:on|the)\s+)?(?:(?:on|the)\s+)?#{DATE_DD}/, '\1 next month')
-      
+
       # "for the next 3 days|weeks|months" --> for 3 days|weeks|months
       nsub!(/for\s+(?:the\s+)?(?:next|following)\s+(\d+)\s+(days|weeks|months)/,'for \1 \2')
-      
+
       # This monthname -> monthname
       nsub!(/this\s+#{MONTH_OF_YEAR}/, '\1')
-      
+
       # Until monthname -> through monthname
       # through shouldn't be included here; through and until mean different things, need to fix wrapper terminology
       # "until june --> through june"
       nsub!(/(?:through|until)\s+(?:this\s+)?#{MONTH_OF_YEAR}\s+(?:$|\D)/, 'through \1')
-      
+
       # the week of 1/2 -> week of 1/2
       nsub!(/(the\s+)?week\s+(of|starting)\s+(the\s+)?/, 'week of ')
-      
+
       # the week ending 1/2 -> week through 1/2
       nsub!(/(the\s+)?week\s+(?:ending)\s+/, 'week through ')
-      
+
       # clean up wrapper terminology
       # This should always be at end of pre-process
       nsub!(/(begin(s|ning)?|start(s|ing)?)(\s+(at|on))?/,'start')
       nsub!(/(\bend(s|ing)?|through|until)(\s+(at|on))?/,'through')
       nsub!(/start\s+(?:(?:this|in)\s+)?#{MONTH_OF_YEAR}/,'start \1')
-      
+
       # 'the' cases; what this is all about is if someone enters "first sunday of the month" they mean one date.  But if someone enters "first sunday of the month until december 2nd" they mean recurring
       # Do these actually do ANYTHING anymore?
       # "on the 3rd sat and sunday of the month" --> "repeats monthly 3rd sat 3rd sun"  OR  "3rd sat this month 3rd sun this month"
@@ -1117,16 +1117,16 @@ module Nickel
           nsub!(/(?:\bon\s+)?(?:the\s+)?(1st|2nd|3rd|4th|5th)\s+((?:#{DAY_OF_WEEK_NB}\s+(?:and\s+)?){2,7})(?:of\s+)?(?:the)\s+month/) {|m1,m2| m2.gsub(/\band\b/,'').gsub(/#{DAY_OF_WEEK}/, m1 + ' \1 this month') }
         end
       end
-      
+
       # "on the 2nd and 3rd sat of this month" --> "repeats monthly 2nd sat 3rd sat"  OR  "2nd sat this month 3rd sat this month"
       if self =~ /(?:\bon\s+)?(?:the\s+)?((?:(?:1st|2nd|3rd|4th|5th)\s+(?:and\s+)?(?:the\s+)?){2,7})#{DAY_OF_WEEK}\s+(?:of\s+)?(?:the)\s+month/
         if self =~ /(start|through)\s+#{DATE_MM_SLASH_DD}/
           nsub!(/(?:\bon\s+)?(?:the\s+)?((?:(?:1st|2nd|3rd|4th|5th)\s+(?:and\s+)?(?:the\s+)?){2,7})#{DAY_OF_WEEK}\s+(?:of\s+)?(?:the)\s+month/) {|m1,m2| "repeats monthly " + m1.gsub(/\b(and|the)\b/,'').gsub(/(1st|2nd|3rd|4th|5th)/, '\1 ' + m2) }
-        else                                                                                                                                     
+        else
           nsub!(/(?:\bon\s+)?(?:the\s+)?((?:(?:1st|2nd|3rd|4th|5th)\s+(?:and\s+)?(?:the\s+)?){2,7})#{DAY_OF_WEEK}\s+(?:of\s+)?(?:the)\s+month/) {|m1,m2| m1.gsub(/\b(and|the)\b/,'').gsub(/(1st|2nd|3rd|4th|5th)/, '\1 ' + m2 + ' this month') }
         end
       end
-      
+
       # "on the 3rd sat and 5th tuesday of this month" --> "repeats monthly 3rd sat 5th tue" OR "3rd sat this month 5th tuesday this month"
       if self =~ /(?:\bon\s+)?(?:the\s+)?((?:(?:1st|2nd|3rd|4th|5th)\s+#{DAY_OF_WEEK_NB}\s+(?:and\s+)?(?:the\s+)?){1,10})(?:of\s+)?(?:the)\s+month/
         if self =~ /(start|through)\s+#{DATE_MM_SLASH_DD}/
@@ -1135,7 +1135,7 @@ module Nickel
           nsub!(/(?:\bon\s+)?(?:the\s+)?((?:(?:1st|2nd|3rd|4th|5th)\s+#{DAY_OF_WEEK_NB}\s+(?:and\s+)?(?:the\s+)?){1,10})(?:of\s+)?(?:the)\s+month/) { |m1| m1.gsub(/\b(and|the)\b/,'').gsub(/#{day_of_week}/,'\1 this month') }
         end
       end
-      
+
       nsub!(/from\s+now\s+(through|to|until)/,'now through')
     end
   end


### PR DESCRIPTION
Example:
    /Users/ross/.rvm/gems/ruby-1.9.2-p136@bleecker/gems/nickel-0.0.5/lib/nickel.rb:22: warning: nested repeat operator + and ? was replaced with '*': /\bany(?:\s+)?day\b/

I updated all of the regular expressions I could find with the more efficient syntax suggested by the warning.
