### PR TITLE
Corrected syntax error (in rubinius) due to no whitespace after '+'

### DIFF
--- a/lib/nickel/query.rb
+++ b/lib/nickel/query.rb
@@ -681,9 +681,9 @@ module Nickel
       # Monthname x through y
       nsub!(/#{MONTH_OF_YEAR}\s+(?:the\s+)?#{DATE_DD_NB_ON_SUFFIX}\s+(?:of\s+)?(?:#{YEAR}\s+)?(?:through|to|until)\s+(?:the\s+)?#{DATE_DD_NB_ON_SUFFIX}(?:\s+of)?(?:\s+#{YEAR})?/) do |m1,m2,m3,m4,m5|
         if m3  # $3 holds first occurrence of year
-          (ZDate.months_of_year.index(m1) + 1).to_s + '/' + m2 + '/' + m3 +' through ' + (ZDate.months_of_year.index(m1) + 1).to_s + '/' + m4 + '/' + m3
+          (ZDate.months_of_year.index(m1) + 1).to_s + '/' + m2 + '/' + m3 + ' through ' + (ZDate.months_of_year.index(m1) + 1).to_s + '/' + m4 + '/' + m3
         elsif m5 # $5 holds second occurrence of year
-          (ZDate.months_of_year.index(m1) + 1).to_s + '/' + m2 + '/' + m5 +' through ' + (ZDate.months_of_year.index(m1) + 1).to_s + '/' + m4 + '/' + m5
+          (ZDate.months_of_year.index(m1) + 1).to_s + '/' + m2 + '/' + m5 + ' through ' + (ZDate.months_of_year.index(m1) + 1).to_s + '/' + m4 + '/' + m5
         else
           (ZDate.months_of_year.index(m1) + 1).to_s + '/' + m2 + ' through ' + (ZDate.months_of_year.index(m1) + 1).to_s + '/' + m4
         end


### PR DESCRIPTION
The current version of nickel doesn't work at all in rubinius, due to a syntax error. This pull request corrects that. The cause was that rubinius can't parse + without being surrounded by whitespace.

Here's the full error:

  A syntax error has occurred:
      expecting keyword_do or '{' or '('
      near line /Users/iain/Dropbox/Programs/OSS/nickel/lib/nickel/query.rb:684, column 75

  Code:
            (ZDate.months_of_year.index(m1) + 1).to_s + '/' + m2 + '/' + m3 +' through ' + (ZDate.months_of_year.index(m1) + 1).to_s + '/' + m4 + '/' + m3
